### PR TITLE
migrate to new public REST API

### DIFF
--- a/conf/index.coffee
+++ b/conf/index.coffee
@@ -4,6 +4,7 @@ module.exports =
   # unless you have a dedicated Livingdocs hosting you will not need to change
   # this.
   api_host: 'http://api.livingdocs.io'
+  # staging test: 'http://staging.api.livingdocs.io'
 
   # NOTE: refer to the readme to see how to customize these values for your own use
 
@@ -11,9 +12,11 @@ module.exports =
   # Use the API access for one of your documents on livingdocs-beta.io and
   # search in the returned JSON for space_id to get your number
   space_id: 127
+  # staging test: 1
 
   # A document you want to use as your start page
   # set this to false or undefined if you want to have teasers
   # ordered automatically by publication date
   start_page_document: 1705
+  # staging test: 1290
 

--- a/shared/controllers.coffee
+++ b/shared/controllers.coffee
@@ -39,12 +39,12 @@ exports.articles = (ctx, next) ->
 exports.article = (ctx, next) ->
   dataSource.getArticle ctx.params.slug, (err, article) ->
     return next(err) if err
-    dependencies = getDependencies(article.data.metadata)
+    dependencies = getDependencies(article.metadata)
     ctx.render 'article.html',
       html: article.html
-      title: article.data.metadata?.title
-      description: article.data.metadata?.description
-      author: article.data.metadata?.author
-      teaserImage: article.data.metadata?.teaserImage?.url
-      dependencies: getDependencies(article.data.metadata)
+      title: article.metadata?.title
+      description: article.metadata?.description
+      author: article.metadata?.author
+      teaserImage: article.metadata?.teaserImage?.url
+      dependencies: getDependencies(article.metadata)
 

--- a/shared/transformers.coffee
+++ b/shared/transformers.coffee
@@ -9,6 +9,6 @@ exports.deduceTitleFromData = (content) ->
 
 exports.articlesToTeasers = (articles) ->
   for art in articles
-    url: art.slug || "/articles/"+ url.normalizeSlug(art.data.metadata?.title || exports.deduceTitleFromData(art.data.content)) + "-#{art.document_id}"
-    title: art.data.metadata?.title || exports.deduceTitleFromData(art.data.content)
-    teaserImage: art.data.metadata?.teaserImage?.url
+    url: art.slug || "/articles/"+ url.normalizeSlug(art.metadata?.title || exports.deduceTitleFromData(art.content)) + "-#{art.document_id}"
+    title: art.metadata?.title
+    teaserImage: art.metadata?.teaserImage?.url


### PR DESCRIPTION
This uses the new top-level `metadata` object instead of the deprecated `data`.
